### PR TITLE
Add basic reconciliation test

### DIFF
--- a/tests/data/billing_test.csv
+++ b/tests/data/billing_test.csv
@@ -1,0 +1,4 @@
+billing_id,billing_date,customer_name,amount,due_date
+B001,2025-07-01,CustomerA,10000,2025-07-31
+B002,2025-07-02,CustomerB,20000,2025-07-31
+B003,2025-07-03,CustomerC,15000,2025-07-31

--- a/tests/data/deposit_test.csv
+++ b/tests/data/deposit_test.csv
@@ -1,0 +1,4 @@
+deposit_id,deposit_date,deposit_amount,deposit_customer
+B001,2025-07-05,10000,CustomerA
+B002,2025-07-10,20000,CustomerB
+B004,2025-07-15,5000,CustomerD

--- a/tests/test_reconciliation_expert.py
+++ b/tests/test_reconciliation_expert.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import pandas as pd
+
+# プロジェクトルートをパスに追加
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from agent.task_agent.reconciliation_expert import ReconciliationExpert
+
+
+def test_load_and_output(tmp_path, monkeypatch):
+    """_load_data と _output_csv の基本動作をテスト"""
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+
+    expert = ReconciliationExpert()
+    df = expert._load_data("tests/data/deposit_test.csv")
+    assert not df.empty
+
+    out_file = tmp_path / "result.csv"
+    message = expert._output_csv(df, str(out_file))
+
+    assert out_file.exists()
+    assert "ファイルを出力しました" in message


### PR DESCRIPTION
## Summary
- create sample billing and deposit CSVs under tests
- add pytest checking load and CSV output functions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851fcec06508322b7f0d7d1601962b4